### PR TITLE
patch chipmunk.pro to compile on linux

### DIFF
--- a/useful/chipmunk.pro
+++ b/useful/chipmunk.pro
@@ -7,6 +7,7 @@
 QT       -= core gui
 
 CXXFLAGS += -fast
+QMAKE_CFLAGS += -std=c99
 
 TARGET = chipmunk
 TEMPLATE = lib


### PR DESCRIPTION
build-essential gcc uses different std version, apparently
