### PR TITLE
linux compilation patch

### DIFF
--- a/GroPainter.cpp
+++ b/GroPainter.cpp
@@ -17,7 +17,7 @@
 //
 //
 
-#include "gropainter.h"
+#include "GroPainter.h"
 
 GroPainter::GroPainter ( QSize s, QPaintDevice * device ):
     QPainter(device),


### PR DESCRIPTION
Case sensitive compilation is default on linux, but not Mac. No clue what sense that makes.
